### PR TITLE
reduce percentEffectRemaining to zero after actionDuration and initialDelay

### DIFF
--- a/LoopKit/InsulinKit/ExponentialInsulinModel.swift
+++ b/LoopKit/InsulinKit/ExponentialInsulinModel.swift
@@ -54,7 +54,7 @@ extension ExponentialInsulinModel: InsulinModel {
         switch time {
         case let t where t <= initialDelay:
             return 1
-        case let t where t >= actionDuration:
+        case let t where t >= (actionDuration + initialDelay):
             return 0
         default:
             return 1 - S * (1 - a) *


### PR DESCRIPTION
Hi @Kdisimone,

Reviewing your Anna branches because I'm planning to try your initial delay logic I believe there's a small correction needed: the remaining insulin effect should drop to zero only after the initial delay and the action duration have completed. Only affects the last 20 minutes of the tail, but could be an issue if people are considering longer delays.